### PR TITLE
feat: expose API endpoint to fetch article list

### DIFF
--- a/src/main/resources/extensions/roleTemplate.yaml
+++ b/src/main/resources/extensions/roleTemplate.yaml
@@ -11,8 +11,11 @@ metadata:
     rbac.authorization.halo.run/display-name: "编辑器RSS"
 rules:
   - apiGroups: ["api.friend.moony.la"]
-    resources: ["parsingrss"]
+    resources: ["parsingrss", "friendposts"]
     verbs: [ "get", "list" ]
+  - apiGroups: ["friend.moony.la"]
+    resources: ["friendposts"]
+    verbs: ["get", "list"]
 
 ---
 


### PR DESCRIPTION
暴露 `获取朋友圈文章` 接口，以供 [halo-theme-hao](https://github.com/chengzhongxue/halo-theme-hao) 实现朋友圈页面，相关 PR: https://github.com/chengzhongxue/halo-theme-hao/pull/878